### PR TITLE
fix: ignore the empty input_text in history

### DIFF
--- a/app/src/main/java/com/tutu/meowhub/core/engine/DoubaoAiProvider.kt
+++ b/app/src/main/java/com/tutu/meowhub/core/engine/DoubaoAiProvider.kt
@@ -53,17 +53,20 @@ class DoubaoAiProvider(
         onToken: ((String) -> Unit)?
     ): String {
         val input = buildJsonArray {
-            addJsonObject {
-                put("role", "system")
-                put("content", buildJsonArray {
-                    addJsonObject {
-                        put("type", "input_text")
-                        put("text", prompt)
-                    }
-                })
+            if (prompt.isNotBlank()) {
+                addJsonObject {
+                    put("role", "system")
+                    put("content", buildJsonArray {
+                        addJsonObject {
+                            put("type", "input_text")
+                            put("text", prompt)
+                        }
+                    })
+                }
             }
 
             for (msg in history) {
+                if (msg.content.isBlank()) continue
                 addJsonObject {
                     put("role", msg.role)
                     put("content", buildJsonArray {


### PR DESCRIPTION
Doubao rejects something like `{"type": "input_text", "text": ""}`

## Summary / 概要

Brief description of the changes.

## Type of Change / 变更类型

- [X] Bug fix / 修复 Bug
- [ ] New feature / 新功能
- [ ] New Skill / 新技能
- [ ] Documentation / 文档
- [ ] Refactoring / 重构
- [ ] Performance improvement / 性能优化

## Changes Made / 具体变更

-

## Testing / 测试

- [ ] Tested on real device
- Device:
- Android Version:

## Related Issues / 相关 Issue

Closes #

## Checklist / 检查清单

- [ ] Code follows the project's style guidelines
- [ ] Self-reviewed the code
- [ ] Updated documentation if needed
- [ ] No new warnings introduced
